### PR TITLE
Filter status

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,4 +18,5 @@ $(document).ready( function(){
   markAsRead();
   markAsUnread();
   searchLinks();
+  filterStatus();
 });

--- a/app/assets/javascripts/filter-status.js
+++ b/app/assets/javascripts/filter-status.js
@@ -1,0 +1,17 @@
+function filterStatus() {
+  $('#link_status_filter').on('change', function(){
+    var status = this.value;
+    $('.link').each(function(index, link) {
+      var $link = $(link);
+      var link_status = $link.data('read') ? "Read" : "Unread";
+
+      if (status === "") {
+        $link.show();
+      } else if (link_status === status) {
+        $link.show();
+      } else {
+        $link.hide();
+      }
+    });
+  });
+}

--- a/app/views/links/index.html.erb
+++ b/app/views/links/index.html.erb
@@ -11,6 +11,11 @@
 <label for="link_search_filter">Search</label>
 <%= text_field :link_search, :filter %>
 
+<br>
+<label>Filter by status:</label>
+<%= select :link_status, :filter, ["Read", "Unread"], {include_blank: true} %>
+<br>
+
 <div id="links-list">
   <% @links.each do |link| %>
     <div class="link read-<%= link.read %>"

--- a/spec/features/user_can_filter_links_by_statuses_spec.rb
+++ b/spec/features/user_can_filter_links_by_statuses_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.feature "UserCanFilterLinksByStatuses", type: :feature do
+  it "should filter links on the page when entering search term", js: true do
+    user = create(:user)
+    user.links.create(title: "JavaScript for Cats", url: "http://jsforcats.com/", read: true)
+    user.links.create(title: "Cats", url: "https://www.reddit.com/r/cats/")
+    user.links.create(title: "Flowers", url: "http://www.bonniebraeflowers.com/")
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    visit '/'
+
+    select "Unread", :from => "link_status[filter]"
+
+    expect(page).to_not have_content("JavaScript for Cats")
+
+    expect(page).to have_content("Cats")
+    expect(page).to have_content("Flowers")
+  end
+end

--- a/spec/features/user_can_filter_links_by_statuses_spec.rb
+++ b/spec/features/user_can_filter_links_by_statuses_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature "UserCanFilterLinksByStatuses", type: :feature do
-  it "should filter links on the page when entering search term", js: true do
+  it "should filter links on the page when selecting unread only", js: true do
     user = create(:user)
     user.links.create(title: "JavaScript for Cats", url: "http://jsforcats.com/", read: true)
     user.links.create(title: "Cats", url: "https://www.reddit.com/r/cats/")
@@ -16,5 +16,38 @@ RSpec.feature "UserCanFilterLinksByStatuses", type: :feature do
 
     expect(page).to have_content("Cats")
     expect(page).to have_content("Flowers")
+  end
+
+  it "should filter links on the page when selecting read only", js: true do
+    user = create(:user)
+    user.links.create(title: "JavaScript for Cats", url: "http://jsforcats.com/")
+    user.links.create(title: "Cats", url: "https://www.reddit.com/r/cats/")
+    user.links.create(title: "Flowers", url: "http://www.bonniebraeflowers.com/", read: true)
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    visit '/'
+
+    select "Read", :from => "link_status[filter]"
+
+    expect(page).to have_content("Flowers")
+
+    expect(page).to_not have_content("Cats")
+    expect(page).to_not have_content("JavaScript for Cats")
+  end
+
+  it "should show all links when selecting blank option", js: true do
+    user = create(:user)
+    user.links.create(title: "JavaScript for Cats", url: "http://jsforcats.com/")
+    user.links.create(title: "RedditCats", url: "https://www.reddit.com/r/cats/")
+    user.links.create(title: "Flowers", url: "http://www.bonniebraeflowers.com/", read: true)
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    visit '/'
+
+    select "", :from => "link_status[filter]"
+
+    expect(page).to have_content("Flowers")
+    expect(page).to have_content("RedditCats")
+    expect(page).to have_content("JavaScript for Cats")
   end
 end


### PR DESCRIPTION
User can select links based on status Read or Unread. Selecting blank will show all links.
